### PR TITLE
enums in graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,20 @@ users(parent,args,ctx,info){
   },
 
 
+
+  Enums in GraphQL
+  1. A special type that defines  a set of constants.
+  2.This type can then be used as a type for the field (similar to scalar and custom object types)
+  3.Values for the field must be one of the constants for the type
+
+  ed. UserRole: standard, editor, admin
+
+  Mutation: Created, Updated, Deleted
+
+This is used to enforce when data is cominf g=from front end.
+
+
+
+
+
+

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -92,13 +92,19 @@ type Comment {
     post:Post!
 }
 
+enum MutationType{
+    CREATED
+    UPDATED
+    DELETED
+}
+
 type PostSubscriptionPayload{
     mutation: String!
     data:Post!
 }
 
 type CommentSubscriptionPayload{
-    mutation: String!
+    mutation: MutationType!
     data: Comment!
 }
 


### PR DESCRIPTION
use enums when we want fixed values to be inserted. like mutationtypes.